### PR TITLE
Harden form field handling

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -82,12 +82,12 @@
           const fd = new FormData(e.currentTarget);
           const payload = {
             customer_uid: user.uid,
-            username: fd.get("username").trim(),
-            name: fd.get("name").trim(),
-            phone: fd.get("phone").trim(),
-            email: fd.get("email").trim(),
+            username: (fd.get("username") || "").toString().trim(),
+            name: (fd.get("name") || "").toString().trim(),
+            phone: (fd.get("phone") || "").toString().trim(),
+            email: (fd.get("email") || "").toString().trim(),
           };
-          const pwd = fd.get("password");
+          const pwd = (fd.get("password") || "").toString();
           if (pwd) payload.password = pwd;
 
           try {

--- a/login.html
+++ b/login.html
@@ -22,8 +22,8 @@
 
         const fd = new FormData(form);
         const payload = {
-          phone: fd.get("phone").trim(),
-          password: fd.get("password"),
+          phone: (fd.get("phone") || "").toString().trim(),
+          password: (fd.get("password") || "").toString(),
         };
 
         if (!payload.phone || !payload.password) {

--- a/register.html
+++ b/register.html
@@ -21,11 +21,11 @@
         status.innerHTML = "";
         const fd = new FormData(form);
         const payload = {
-          username: fd.get("username").trim(),
-          name: fd.get("name").trim(),
-          phone: fd.get("phone").trim(),
-          password: fd.get("password"),
-          email: fd.get("email").trim(),
+          username: (fd.get("username") || "").toString().trim(),
+          name: (fd.get("name") || "").toString().trim(),
+          phone: (fd.get("phone") || "").toString().trim(),
+          password: (fd.get("password") || "").toString(),
+          email: (fd.get("email") || "").toString().trim(),
         };
 
         // basic client-side checks


### PR DESCRIPTION
## Summary
- prevent login/register/update forms from throwing when expected fields are absent by defaulting FormData lookups to empty strings

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689ebc29634883239044476cb603e942